### PR TITLE
Add GitHub action for staging deploy

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,88 @@
+name: Deploy jobs.zooniverse.org Staging
+
+on:
+    # Run this workflow on push to master (incl PR merges)
+    push:
+        branches: [ master ]
+
+    # Allow running this workflow manually from the Actions tab
+    workflow_dispatch:
+
+jobs:
+  deploy_staging:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: azure/login@v1
+      with:
+          creds: ${{ secrets.AZURE_STATIC_SITES }}
+
+    - name: Node.js build
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - run: npm install
+    - run: npm run build
+
+    - name: Upload to blob storage
+      uses: azure/CLI@v1
+      with:
+        creds: ${{ secrets.AZURE_STATIC_SITES }}
+        inlineScript: |
+            az storage blob upload-batch \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, immutable, max-age=604800' \
+              --destination '$web/preview.zooniverse.org/jobs' \
+              --source ./build
+            az storage blob upload \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, max-age=60' \
+              --container-name '$web' \
+              --name 'preview.zooniverse.org/jobs/index.html' \
+              --file ./build/index.html
+    - name: Slack notification
+      uses: 8398a7/action-slack@v3
+      if: always()
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        fields: took
+        status: custom
+        custom_payload: |
+          {
+            "channel": "#deploys",
+            "icon_emoji": ":octocat:",
+            "username": "Deploy Action",
+            "attachments": [{
+              "color": '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              "mrkdwn_in": ["text"],
+              "author_name": "${{ github.actor }}",
+              "author_link": "https://github.com/${{ github.actor }}/",
+              "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
+              "title": "jobs.zooniverse.org staging deploy complete",
+              "title_link": "https://preview.zooniverse.org/jobs/",
+              "fields": [
+                  {
+                      "title": "Status",
+                      "value": '${{ job.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ job.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
+                      "short": true
+                  },
+                  {
+                      "title": "Triggered by",
+                      "value": "${{ github.event_name }}",
+                      "short": true
+                  },
+                  {
+                      "title": "Run Link",
+                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+              ],
+              "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
+              "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
+              "footer_icon": "https://www.zooniverse.org/favicon.ico"
+            }]
+          }
+# Azure logout
+    - name: logout
+      run: |
+            az logout

--- a/haw-build-config.json
+++ b/haw-build-config.json
@@ -1,0 +1,6 @@
+{
+  "generate": {
+    "/index.html": "public/index.{html,eco}",
+    "/main.css": "css/main.{css,styl}"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   },
   "scripts": {
     "start": "haw serve --port 1085",
-    "build": "haw build"
+    "build": "haw build --config ./haw-build-config.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "start": "haw serve --port 1085",
-    "deploy": "haw build && publisssh ./build zooniverse-static/jobs.zooniverse.org && rm -rf ./build",
-    "stage": "haw build && publisssh ./build zooniverse-static/preview.zooniverse.org/jobs && rm -rf ./build"
+    "build": "haw build"
   }
 }


### PR DESCRIPTION
Add GitHub Action for staging deploy, based on Notes from Nature Field Book's staging GitHub Action.

Noting this repo is using an old compiling package called [`haw`](https://www.npmjs.com/package/haw) and was last built and deployed with old node/npm versions. I was able to build and serve locally (with Node v14), though I won't be surprised if there is an issue, but we'll see.