### PR TITLE
Update Deploys

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,88 +1,42 @@
 name: Deploy jobs.zooniverse.org Staging
 
 on:
-    # Run this workflow on push to master (incl PR merges)
+    # Run this workflow on creation (or sync to source branch) of a new pull request
     push:
-        branches: [ master ]
+        branches:
+          - master
 
-    # Allow running this workflow manually from the Actions tab
-    workflow_dispatch:
+    # TEMPORARY Run this workflow on creation (or sync to source branch) of a new pull request
+    pull_request:
 
 jobs:
+  build:
+    name: Build staging
+    uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
+    with:
+      commit_id: ${{ github.sha }}
+      node_version: '16.x'
+      output: 'build'
+      script: '_build-staging'
   deploy_staging:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: azure/login@v1
-      with:
-          creds: ${{ secrets.AZURE_STATIC_SITES }}
-
-    - name: Node.js build
-      uses: actions/setup-node@v1
-      with:
-        node-version: '14.x'
-    - run: npm install
-    - run: npm run build
-
-    - name: Upload to blob storage
-      uses: azure/CLI@v1
-      with:
-        creds: ${{ secrets.AZURE_STATIC_SITES }}
-        inlineScript: |
-            az storage blob upload-batch \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, immutable, max-age=604800' \
-              --destination '$web/preview.zooniverse.org/jobs' \
-              --source ./build
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60' \
-              --container-name '$web' \
-              --name 'preview.zooniverse.org/jobs/index.html' \
-              --file ./build/index.html
-    - name: Slack notification
-      uses: 8398a7/action-slack@v3
-      if: always()
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        fields: took
-        status: custom
-        custom_payload: |
-          {
-            "channel": "#deploys",
-            "icon_emoji": ":octocat:",
-            "username": "Deploy Action",
-            "attachments": [{
-              "color": '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              "mrkdwn_in": ["text"],
-              "author_name": "${{ github.actor }}",
-              "author_link": "https://github.com/${{ github.actor }}/",
-              "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-              "title": "jobs.zooniverse.org staging deploy complete",
-              "title_link": "https://preview.zooniverse.org/jobs/",
-              "fields": [
-                  {
-                      "title": "Status",
-                      "value": '${{ job.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ job.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
-                      "short": true
-                  },
-                  {
-                      "title": "Triggered by",
-                      "value": "${{ github.event_name }}",
-                      "short": true
-                  },
-                  {
-                      "title": "Run Link",
-                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-              ],
-              "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
-              "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
-              "footer_icon": "https://www.zooniverse.org/favicon.ico"
-            }]
-          }
-# Azure logout
-    - name: logout
-      run: |
-            az logout
+    name: Deploy staging
+    uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main
+    needs: build
+    with:
+      source: 'build'
+      target: 'preview.zooniverse.org/jobs'
+    secrets:
+      creds: ${{ secrets.AZURE_STATIC_SITES }}
+  slack_notification:
+    name: Send Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy_staging
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Build staging / build
+      status: ${{ needs.deploy_staging.result }}
+      title: 'Deploy jobs.zooniverse.org Staging complete'
+      title_link: 'https://jobs.preview.zooniverse.org'
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## PR Overview

This PR attempts to fix the deploy scripts for jobs.zooniverse.org

At the moment, [deployments are failing](https://github.com/zooniverse/jobs.zooniverse.org/actions/runs/2091135872) and the likely culprit is that the deploy scripts are _old._ Based on Zach's feedback, I'm going to try copying the deploy scripts for [PFE](https://github.com/zooniverse/Panoptes-Front-End/blob/0a3f49c50f70420c6c9a9aeade25c7f44effb8d5/.github/workflows/deploy_staging.yml)