### PR TITLE
Remove info for Oxford Web Developer internship 2022

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -38,42 +38,6 @@
           <h3 class="oxford location-heading">Oxford</h3>
           <p class="introduction">The Zooniverse team at the University of Oxford are leading the development of the new Zooniverse platform, as well as projects covering everything from Penguins to Particle Physics, all the way up to disaster relief. We encourage flexible working, including working remotely for part of each week.</p>
 
-          <div class="job">
-            <p><a class="job-title" id="oxford-web-developer-internship">Web Developer - Paid 3 month Internship</a></p>
-            <div class="job description">
-
-              <p><a href="https://www.zooniverse.org" target="_blank">The Zooniverse</a> is the world's largest and most popular platform for people-powered research, and the team is excited to offer a web developer work experience opportunity via a paid 3 month internship (UK living wage).</p>
-
-              <p>This is a remote-first position and is open to anyone based in (and has the right to work in) the UK. While the position is remote, we will require the candidate to visit the office in Oxford at least twice to meet the team and have some tea.</p>
-
-              <p>What you can expect:</p>
-              <ul>
-                <li>You'll be working with our team of front end & back end developers to build features and make improvements for our Zooniverse.org platform. Our code's open source, so if you're curious about what we do, you can take a look at <a href="https://github.com/zooniverse/" target="_blank">https://github.com/zooniverse/</a></li>
-                <li>You'll learn not only from developers, but also from researchers from a variety of scientific disciplines.</li>
-                <li>The format of the internship will vary based on the candidate's experience, with time allocated for self-directed learning and tea breaks. (Coffee is also acceptable.)</li>
-              </ul>
-
-              <p>What we expect:</p>
-              <ul>
-                <li>We're looking for somebody who's curious to learn, keen to take initiative, and isn’t afraid to try and build things.</li>
-                <li>We care about what we build online and how it affects people in the real world, and we want you to feel the same.</li>
-                <li>You should be comfortable asking questions even if they seem simple and obvious, such as "why was this designed this way?", "how does this work?", or "do we share lots of pet photos on chat?" (Yes, obviously.)</li>
-              </ul>
-
-              <p>The only "skill" you really need to apply is a genuine interest to learn and grow. The following skills are "nice to haves", but if you don't possess them, expect to learn with the support of the team:</p>
-              <ul>
-                <li>Any experience with web development (HTML, CSS, JavaScript) or programming in general.</li>
-                <li>An understanding of how the Internet works: the HTTP protocol, web sockets, etc.</li>
-                <li>Any experience with collaborative software development systems, e.g. GitHub.</li>
-                <li>Any experience with UI design or crafting User Experiences (UX).</li>
-                <li>We're also interested in any other experience or skill you think might be relevant to this opportunity.</li>
-              </ul>
-
-              <p>The internship will run over the summer of 2022, with exact dates to be negotiated. If you would like to apply for this position, please email an up-to-date copy of your CV and a letter of interest to <a href="mailto:internship@zooniverse.org">internship@zooniverse.org</a>.</p>
-
-            </div>
-          </div>
-
         </section>
 
         <section class="column content-container">


### PR DESCRIPTION
## PR Overview

This PR removes the entry for the 2022 internship position in Oxford. Thank you to everyone who took their time to apply for this position!