### PR TITLE
Update checkout & upload-artifact actions to v4

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -7,11 +7,11 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Write commit_id.txt
         run: echo ${{ github.sha }} > ./build/commit_id.txt
       - name: Upload files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'build'
           path: ./build

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -13,11 +13,11 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Write commit_id.txt
         run: echo ${{ github.sha }} > ./build/commit_id.txt
       - name: Upload files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'build'
           path: ./build

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -13,11 +13,11 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Write commit_id.txt
         run: echo ${{ github.sha }} > ./build/commit_id.txt
       - name: Upload files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'build'
           path: ./build


### PR DESCRIPTION
Updates `actions/checkout` and `actions/upload-artifact`. Shared ones were updated in the shared ci-cd repo and the v3 actions here are incompatible with the v4 download-artifact call in the deploy_static workflow.